### PR TITLE
Feat: get User TailwindCSS Data

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,13 +1,14 @@
 const vscode = require("vscode");
 const { getCssData, getTailwindToCssData } = require("./getData");
 const getStyledComponentsData = require("./getUserStyledComponents");
-const setBrowserAndversion = require("./setBrowserAndVersion");
+const setBrowserAndVersion = require("./setBrowserAndVersion");
 
 /**
  * @param {vscode.ExtensionContext} context
  */
 async function activate(context) {
   const cssData = await getCssData();
+  const tailwindToCss = await getTailwindToCssData();
   let userCssData;
 
   const checkCompatibilityAndGetInfo = vscode.commands.registerCommand(
@@ -32,9 +33,10 @@ async function activate(context) {
       ) {
         userCssData = getStyledComponentsData();
       } else {
+        userCssData = getUserTailwindData(tailwindToCss);
       }
 
-      const userSelection = await setBrowserAndversion(agentData);
+      const userSelection = await setBrowserAndVersion(agentData);
     },
   );
 

--- a/getUserTailwindData.js
+++ b/getUserTailwindData.js
@@ -53,6 +53,7 @@ function getUserTailwindData(tailwindToCss) {
       });
     });
   });
+
   return cssProperties;
 }
 

--- a/getUserTailwindData.js
+++ b/getUserTailwindData.js
@@ -1,0 +1,59 @@
+const vscode = require("vscode");
+
+function getUserTailwindData(tailwindToCss) {
+  const editor = vscode.window.activeTextEditor;
+
+  if (!editor) {
+    vscode.window.showInformationMessage("편집기가 활성화되어 있지 않습니다.");
+
+    return;
+  }
+
+  const document = editor.document;
+  const tailwindProperties = [];
+  const cssProperties = [];
+  const text = document.getText();
+  const regex = /className=["|']([^"|']+)["|']/g;
+  let match;
+
+  while ((match = regex.exec(text)) !== null) {
+    match[1].split(/\s+/).forEach(cssProperty => {
+      tailwindProperties.push(cssProperty);
+    });
+  }
+
+  tailwindProperties.forEach(word => {
+    tailwindToCss.forEach(element => {
+      element.content.forEach(content => {
+        content.table.forEach(list => {
+          list.forEach(info => {
+            if (info === word) {
+              list.forEach(css => {
+                if (css.includes(":")) {
+                  if (css.split(":").length !== 2) {
+                    const cssSplitArr = css.split("\n");
+
+                    cssSplitArr.forEach(multi => {
+                      cssProperties.push({
+                        tw: word,
+                        css: multi.split(":")[0],
+                      });
+                    });
+                  } else {
+                    cssProperties.push({
+                      tw: word,
+                      css: css.split(":")[0],
+                    });
+                  }
+                }
+              });
+            }
+          });
+        });
+      });
+    });
+  });
+  return cssProperties;
+}
+
+module.exports = getUserTailwindData;


### PR DESCRIPTION
# [VS Code] 사용자가 작성한 코드에서 CSS 속성 불러오기
- https://dune-hammer-c89.notion.site/VS-Code-CSS-a451a14d0bac4ce3b6941cfcbfc0b5d3?pvs=4

## Description
- 사용자의 TailwindCSS를 가져오기 위해 페이지 내에서 사용된 'className'을 찾아 진행하였습니다.
- npm package 또는 Electron에서와 같이 build를 진행하지 않았습니다. 그 이유는 한 페이지에서만 진행하기 때문에 비효율적이라고 생각되었습니다.
- build를 진행하지 않았기 때문에 ['tailwind_to_css'](https://github.com/Devzstudio/tailwind_to_css) 데이터를 활용하여 TailwindCSS class에 해당하는 CSS 속성을 가져왔습니다.

## Changes
- 기존의 `setBrowserAndversion`으로 작성된 변수명을 `setBrowserAndVersion`으로 변경하였습니다.

## Checklists
- [X] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [X] 코드 스타일을 잘 확인했는가?
