### PR TITLE
Feat: underline not supported CSS

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,7 @@ const { getCssData, getTailwindToCssData } = require("./getData");
 const getStyledComponentsData = require("./getUserStyledComponents");
 const setBrowserAndVersion = require("./setBrowserAndVersion");
 const checkCompatibility = require("./compatibilityCheck");
+const { markLine } = require("./lineMarkAndHover");
 
 /**
  * @param {vscode.ExtensionContext} context
@@ -44,6 +45,8 @@ async function activate(context) {
         cssData,
         userSelection,
       );
+
+      markLine(notSupportedCss);
     },
   );
 

--- a/lineMarkAndHover.js
+++ b/lineMarkAndHover.js
@@ -1,0 +1,49 @@
+const vscode = require("vscode");
+
+async function markLine(notSupportedCss) {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showInformationMessage("편집기가 활성화되어 있지 않습니다.");
+
+    return;
+  }
+
+  const document = editor.document;
+  const text = document.getText();
+  const diagnostics = [];
+
+  function isDuplicateDiagnostic(newDiagnostic) {
+    return diagnostics.some(
+      (diagnostic) =>
+        diagnostic.range.isEqual(newDiagnostic.range) &&
+        diagnostic.message === newDiagnostic.message
+    );
+  }
+
+  for (const property of notSupportedCss) {
+    const regex = new RegExp(property.tw || property.css, "g");
+    let match;
+
+    while ((match = regex.exec(text)) !== null) {
+      const startPos = document.positionAt(match.index);
+      const endPos = document.positionAt(match.index + match[0].length);
+      const range = new vscode.Range(startPos, endPos);
+      const diagnostic = new vscode.Diagnostic(
+        range,
+        "Check Your CSS",
+        vscode.DiagnosticSeverity.Warning
+      );
+
+      if (!isDuplicateDiagnostic(diagnostic)) {
+        diagnostics.push(diagnostic);
+      }
+    }
+  }
+
+  const diagnosticCollection =
+    vscode.languages.createDiagnosticCollection("cssCompatibility");
+
+  diagnosticCollection.set(document.uri, diagnostics);
+}
+
+module.exports = { markLine };


### PR DESCRIPTION
# Title
- [[VS Code] 호환되지 않는 CSS 속성 표시하기](https://dune-hammer-c89.notion.site/VS-Code-CSS-6b829cfe1ea049f5b687aa4b4ae0a037?pvs=4)

## Description
- 호환성 체크 후 호환되지 않는 css속성들에 밑줄치는 기능을 구현하였습니다.
- vscode.Diagnotic을 사용하여 에디터 내에 진단 정보를 표시하였습니다.
- 문제의 위치를 vscode.Range객체를 사용해서 지정하면 문제의 코드의 시작점부터 끝점까지 표시할 수 있습니다.

## Etc
<img width="327" alt="스크린샷 2024-02-22 오후 9 56 30" src="https://github.com/TeamTitans1/checkyourcss-vscode/assets/115441816/ae20e563-7e41-47a9-bd3b-6f28c97b3298">

## Checklists
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
