### PR TITLE
Feat show hover information

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -55,6 +55,7 @@ async function activate(context) {
 
       function provideHover(document, position) {
         const currentHoverPosition = `${position.line}:${position.character}`;
+
         if (lastHoverPosition === currentHoverPosition) {
           return;
         }

--- a/extension.js
+++ b/extension.js
@@ -5,6 +5,8 @@ const setBrowserAndVersion = require("./setBrowserAndVersion");
 const getStyledComponentsData = require("./getUserStyledComponents");
 const { markLine } = require("./lineMarkAndHover");
 const { getCssData, getTailwindToCssData } = require("./getData");
+const extractWordAtPositionIncludingHyphen = require("./getWordIncludingHyphen");
+const bcd = require("@mdn/browser-compat-data");
 
 /**
  * @param {vscode.ExtensionContext} context
@@ -48,6 +50,127 @@ async function activate(context) {
       );
 
       markLine(notSupportedCss);
+
+      let lastHoverPosition = null;
+
+      function provideHover(document, position) {
+        const currentHoverPosition = `${position.line}:${position.character}`;
+        if (lastHoverPosition === currentHoverPosition) {
+          return;
+        }
+
+        lastHoverPosition = currentHoverPosition;
+
+        const word = extractWordAtPositionIncludingHyphen(document, position);
+
+        if (!word) {
+          return;
+        }
+
+        const cssProperty = notSupportedCss.find(
+          cssInfo => cssInfo.css === word || cssInfo.tw === word,
+        );
+
+        const browsersAndSupportedVersion = [];
+
+        userSelection.forEach(selection => {
+          const browserName = convertBrowserName(selection.browser);
+
+          if (cssProperty.css in cssData.data.data) {
+            const browserCompatibilityByVersions =
+              cssData.data.data[cssProperty.css].stats[browserName];
+
+            for (const version in browserCompatibilityByVersions) {
+              const compatibility = browserCompatibilityByVersions[version];
+
+              if (compatibility[0] === "y") {
+                browsersAndSupportedVersion.push({
+                  browser: selection.browserName,
+                  version: version,
+                });
+                break;
+              }
+            }
+          } else if (cssProperty.css in bcd.css.properties) {
+            const stat =
+              bcd.css.properties[cssProperty.css].__compat.support[browserName];
+
+            if (
+              typeof selection.version === "string" &&
+              selection.version.includes("-")
+            ) {
+              versionRangeToVersion = convertToNumberWithOneDecimal(
+                selection.version,
+              );
+            }
+
+            const propertyAddedVersion = Array.isArray(stat)
+              ? parseInt(stat[0].version_added)
+              : parseInt(stat.version_added);
+
+            browsersAndSupportedVersion.push({
+              browser: selection.browserName,
+              version: propertyAddedVersion,
+            });
+          }
+        });
+
+        function convertToNumberWithOneDecimal(numberRangeStr) {
+          const parts = numberRangeStr.split("-");
+          const numbers = parts.map(part => {
+            const match = part.match(/^\d+\.\d?/);
+
+            return match ? parseFloat(match[0]) : NaN;
+          });
+          const average = (numbers[0] + numbers[1]) / 2;
+
+          return Math.round(average * 10) / 10;
+        }
+
+        function convertBrowserName(browserStat) {
+          switch (browserStat) {
+            case "samsung":
+              return "samsunginternet_android";
+            case "and_chr":
+              return "chrome_android";
+            case "android":
+              return "webview_android";
+            case "ios_saf":
+              return "safari_ios";
+            case "and_ff":
+              return "firefox_android";
+            default:
+              return browserStat;
+          }
+        }
+
+        if (cssProperty.css) {
+          const compatibilityInfo = new vscode.MarkdownString();
+
+          compatibilityInfo.appendMarkdown(`### ${cssProperty.css}\n\n`);
+          browsersAndSupportedVersion.forEach(browserAndversion => {
+            compatibilityInfo.appendMarkdown(
+              `- **${browserAndversion.browser}**: Version **${browserAndversion.version}** supported and higher.\n\n`,
+            );
+          });
+          compatibilityInfo.appendMarkdown(
+            `[Find information on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/${cssProperty.css})`,
+          );
+
+          return new vscode.Hover(compatibilityInfo);
+        }
+      }
+
+      const languages = ["javascript", "javascriptreact", "html"];
+
+      languages.forEach(language => {
+        const hoverProvider = vscode.languages.registerHoverProvider(
+          { language, scheme: "file" },
+          { provideHover },
+        );
+
+        context.subscriptions.push(hoverProvider);
+      });
     },
   );
 

--- a/getWordIncludingHyphen.js
+++ b/getWordIncludingHyphen.js
@@ -1,0 +1,18 @@
+function extractWordAtPositionIncludingHyphen(document, position) {
+  const textLine = document.lineAt(position.line).text;
+  const regex = /[\w-]+/g;
+  let match;
+
+  while ((match = regex.exec(textLine)) !== null) {
+    const start = match.index;
+    const end = start + match[0].length;
+
+    if (start <= position.character && position.character <= end) {
+      return match[0];
+    }
+  }
+
+  return null;
+}
+
+module.exports = extractWordAtPositionIncludingHyphen;


### PR DESCRIPTION
# Title
- [[VS Code] 호환되지 않는 CSS 속성 hover시 설명 띄어주기](https://dune-hammer-c89.notion.site/VS-Code-CSS-hover-bb9d5a12059b4624ad5a1f4bb24514b5?pvs=4)

## Description
- 마우스를 호환하지 않는 css속성위에 올려두면 "-"으로 이어진 css속성을 포함하여 호환성 정보를 나타냅니다.
- 호환성 정보를 보여주기 위해 호환하지 않는 css속성들의 호환성 정보를 가져와 hover창에 보여줍니다.
- 호환성 정보를 버전별로 확인 할 때, 버전이 10.1-10.3과 같이 되어있는 경우에도 처리가 가능할 수 있도록 convertToNumberWithOneDecimal함수를 만들었습니다.
- hover창에 마크다운문법이 적용 가능하므로 조금 더 가독성 있도록 코드 작성 하였습니다.
- 호환하지 않는 css에 대한 자세한 정보를 찾아볼 수 있도록 mdn을 바로 갈 수 있도록 하였습니다.

## Focus
- 정보를 조금 더 잘 보여줄 수 있는 방식이 생각나신다면 알려주시길 바랍니다.


## Etc
![스크린샷 2024-02-23 오후 9 54 30](https://github.com/TeamTitans1/checkyourcss-vscode/assets/115441816/82835ef0-95e5-42da-bd29-3639e1308ffc)


## Checklists
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
