### PR TITLE
Refactor: get userSelections data from settings.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,44 @@
       {
         "command": "cyc.fixyourcss",
         "title": "Fix Your CSS"
+      },
+      {
+        "command": "cyc.setSettingJson",
+        "title": "Set Setting.json"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Check Your CSS",
+      "properties": {
+        "checkYourCSS.browsersAndVersions": {
+          "type": "array",
+          "default": [],
+          "description": "Configure browsers and their versions",
+          "items": {
+            "type": "object",
+            "properties": {
+              "browserName": {
+                "type": "string",
+                "description": "browserName"
+              },
+              "browser": {
+                "type": "string",
+                "description": "stat"
+              },
+              "version": {
+                "type": "string",
+                "description": "version"
+              }
+            },
+            "required": [
+              "browser",
+              "version"
+            ]
+          }
+        }
+      }
+    }
   },
   "scripts": {
     "lint": "eslint .",

--- a/src/settingJsonData.js
+++ b/src/settingJsonData.js
@@ -1,0 +1,10 @@
+const vscode = require("vscode");
+
+function getSettingJsonData() {
+  const config = vscode.workspace.getConfiguration();
+  const browserSettings = config.get("checkYourCSS.browsersAndVersions", []);
+
+  return browserSettings;
+}
+
+module.exports = getSettingJsonData;


### PR DESCRIPTION
# Title
- [[vscode extension] 브라우저&버전 설정](https://dune-hammer-c89.notion.site/vscode-extension-121afec5774c4d7f9175dd899034fe6f?pvs=4)

## Description
- Check Your CSS를 실행시킬 때마다 브라우저와 버전을 설정하던 방식에서 초기에 확인하고 싶은 브라우저와 버전을 설정하고 그 이후 호환성을 검사할 때마다 설정해두었던 설정대로 검사하는 로직으로 변경하였습니다.
- 설정을 변경하고 싶으면 Set setting.json을 실행시키고 실행 후 브라우저와 버전 설정하면 설정이 업데이트 됩니다.

## Changes (Optional)
- 호환성을 검사 할 때 마다 설정을 매번 하는 것이 불편하다고  생각되어 수정하였습니다.

## Checklists
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
