### PR TITLE
Refactor: check css compatibility before saving

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,16 +14,12 @@
   "contributes": {
     "commands": [
       {
-        "command": "cyc.checkyourcss",
-        "title": "Check Your CSS"
+        "command": "cyc.setSettingJson",
+        "title": "Check Your CSS: Set Browsers and Versions"
       },
       {
         "command": "cyc.fixyourcss",
         "title": "Fix Your CSS"
-      },
-      {
-        "command": "cyc.setSettingJson",
-        "title": "Set Setting.json"
       }
     ],
     "configuration": {


### PR DESCRIPTION
# Title
- 호환성 체크하는 방식을 command + s로 변경

## Description
- Command Palette를 열어서 Check Your Css를 실행시켜 호환성을 체크하는 방식에서 command + s로 저장되기 전에 체크하는 방식으로 변경하였습니다.

## Focus
- settings.json에 사용자가 선택한 브라우저와 버전을 Command Palette에서 Set Browsers and Versions을 실행시켜 설정하였는데 더 좋은 방법 있으면 알려주시길 바랍니다. 

## Checklists
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
